### PR TITLE
Resolve $HOME in profile.d at runtime rather than during the build

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -29,11 +29,11 @@ VENDOR_DIR="$BUILD_DIR/vendor"
 INSTALL_DIR="$VENDOR_DIR/pandoc"
 BIN_DIR="$INSTALL_DIR/bin"
 SHARE_DIR="$INSTALL_DIR/share"
-REAL_DIR="$HOME/vendor/pandoc/bin"
+RUNTIME_DIR="\$HOME/vendor/pandoc/bin"
 DEB_ARCHIVE_BINARIES="data.tar.xz"
 PANDOC_PKG="$CACHE_DIR/$PANDOC_RELEASE"
 
-mkdir -p $BUILD_DIR $CACHE_DIR $VENDOR_DIR $INSTALL_DIR $BIN_DIR $SHARE_DIR $REAL_DIR
+mkdir -p $BUILD_DIR $CACHE_DIR $VENDOR_DIR $INSTALL_DIR $BIN_DIR $SHARE_DIR
 
 verbose "BUILD_DIR: $BUILD_DIR"
 verbose "CACHE_DIR: $CACHE_DIR"
@@ -41,7 +41,7 @@ verbose "VENDOR_DIR: $VENDOR_DIR"
 verbose "INSTALL_DIR: $INSTALL_DIR"
 verbose "BIN_DIR: $BIN_DIR"
 verbose "SHARE_DIR: $SHARE_DIR"
-verbose "REAL_DIR: $REAL_DIR"
+verbose "RUNTIME_DIR: $RUNTIME_DIR"
 
 if [ -f $PANDOC_PKG ]; then
   verbose "Using cached pandoc pkg: $PANDOC_PKG"
@@ -73,7 +73,7 @@ ls -lR $BIN_DIR | indent
 
 PROFILE_PATH="$BUILD_DIR/.profile.d/pandoc.sh"
 mkdir -p $(dirname $PROFILE_PATH)
-echo "export PATH=$REAL_DIR:\$PATH" > $PROFILE_PATH
+echo "export PATH=$RUNTIME_DIR:\$PATH" > $PROFILE_PATH
 
 verbose "created $PROFILE_PATH:"
 cat $PROFILE_PATH | indent


### PR DESCRIPTION
Previously the value for `$HOME` was resolved at build time, meaning its actual value during the build is hardcoded in the `.profile.d/` script, rather than just the variable name.

Whilst the value for `$HOME` is currently the same at both build-time and run-time (both `/app`), the build-time value (only) is due to change in the future to a path under `/tmp`, which would cause this buildpack to break.


By escaping the dollar sign, the variable `$HOME` is now resolved at runtime, making the buildpack compatible with this future change.

The mkdir of that directory has been removed, since it's unnecessary (nothing is put there during the build, it exists only at runtime).

Fixes #6.